### PR TITLE
Fix Hamburger icon display issue on login page

### DIFF
--- a/src/components/Navbar/Navbar.jsx
+++ b/src/components/Navbar/Navbar.jsx
@@ -30,8 +30,16 @@ function Navbar({toggleSidebar}) {
         <div className="container-fluid">
           <div className="logoContainer">
             <a className="logo" href="/">Dixon Technologies</a>
-            <img className="hamburger-icon" draggable={false} src={menu} onClick={toggleSidebar}/>
+              {user && (
+              <img
+              className="hamburger-icon"
+              draggable={false}
+              src={menu}
+              onClick={toggleSidebar}
+              />
+            )}
           </div>
+
           <form className="d-flex" role="search">
             <input
               className=" inputSearch"


### PR DESCRIPTION
Description of the Fix
This pull request fixes the visibility of the hamburger icon so that it is no longer shown on the login page. The icon will now only appear after a successful login, ensuring users do not see the hamburger menu before authentication. This improves the user interface consistency and aligns with the intended design.

Issue Reference
Closes #11 

After Fix: 
<img width="1919" height="871" alt="image" src="https://github.com/user-attachments/assets/23d2008a-ca39-4d11-a602-1b90f54ca30d" />
